### PR TITLE
Update analysis prompt with optional session details

### DIFF
--- a/src/services/aiAnalysis.ts
+++ b/src/services/aiAnalysis.ts
@@ -89,6 +89,36 @@ export class AIAnalysisService {
         ? efforts.reduce((a, b) => a + b, 0) / efforts.length
         : 0;
 
+    const gradeSystemLine = session.gradeSystem
+      ? `- Grade system: ${session.gradeSystem}`
+      : "";
+    const notesLine = session.notes ? `- Notes: ${session.notes}` : "";
+    const breaksLine =
+      session.breaks || session.totalBreakTime
+        ? `- Breaks taken: ${session.breaks} (total ${session.totalBreakTime} minutes)`
+        : "";
+
+    const climbDetails = session.climbs
+      .map((climb) => {
+        const parts = [
+          `- ${climb.name} (${climb.grade}): ${climb.tickType}`,
+          climb.effort !== undefined ? `effort ${climb.effort}/10` : undefined,
+          climb.height !== undefined ? `height ${climb.height}m` : undefined,
+          climb.timeOnWall !== undefined
+            ? `time on wall ${climb.timeOnWall}s`
+            : undefined,
+          climb.physicalSkills && climb.physicalSkills.length > 0
+            ? `physical skills: ${climb.physicalSkills.join(", ")}`
+            : undefined,
+          climb.technicalSkills && climb.technicalSkills.length > 0
+            ? `technical skills: ${climb.technicalSkills.join(", ")}`
+            : undefined,
+          climb.notes ? `notes: ${climb.notes}` : undefined,
+        ].filter(Boolean);
+        return parts.join(", ");
+      })
+      .join("\n");
+
     return `Analyze this climbing session and provide specific feedback based on the actual performance data.
 
 SESSION DATA:
@@ -102,14 +132,12 @@ SESSION DATA:
 - Onsights: ${onsights}
 - Average effort: ${avgEffort.toFixed(1)}/10
 - Grades: ${grades.join(", ")}
+${gradeSystemLine ? `\n${gradeSystemLine}` : ""}
+${notesLine ? `\n${notesLine}` : ""}
+${breaksLine ? `\n${breaksLine}` : ""}
 
 CLIMBS DETAILS:
-${session.climbs
-  .map(
-    (climb) =>
-      `- ${climb.name} (${climb.grade}): ${climb.tickType}${climb.effort ? `, effort ${climb.effort}/10` : ""}${climb.notes ? `, notes: ${climb.notes}` : ""}`,
-  )
-  .join("\n")}
+${climbDetails}
 
 Please provide analysis in exactly this format:
 


### PR DESCRIPTION
## Summary
- enrich analysis prompt by including optional session-level notes, grade system and breaks
- append optional climb info such as height, time on wall and skill tags

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68427e072a188331bb2ceda57826ef28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced AI analysis to include more detailed session and climb information, such as grade system, notes, breaks, and comprehensive climb attributes in the analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->