### PR TITLE
Add Supabase storage for AI session analysis

### DIFF
--- a/src/components/SessionAnalysis.tsx
+++ b/src/components/SessionAnalysis.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { Session } from "@/types/climbing";
+import { Session, AIAnalysis } from "@/types/climbing";
 import { AIAnalysisService, AnalysisResult } from "@/services/aiAnalysis";
 import AISettingsForm from "./AISettingsForm";
 import SessionAnalysisHeader from "./SessionAnalysisHeader";
@@ -13,10 +13,7 @@ import { OPENROUTER_CONFIG } from "@/config/openrouter";
 interface SessionAnalysisProps {
   session: Session;
   onClose: () => void;
-  onAnalysisSaved?: (
-    sessionId: string,
-    analysis: Session["aiAnalysis"],
-  ) => void;
+  onAnalysisSaved?: (sessionId: string, analysis: AIAnalysis) => void;
   autoStart?: boolean;
 }
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -159,6 +159,42 @@ export type Database = {
         };
         Relationships: [];
       };
+      session_analyses: {
+        Row: {
+          created_at: string;
+          id: string;
+          session_id: string;
+          summary: string;
+          strengths: string[] | null;
+          areas_for_improvement: string[] | null;
+          recommendations: string[] | null;
+          progress_insights: string | null;
+          user_id: string | null;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          session_id: string;
+          summary: string;
+          strengths?: string[] | null;
+          areas_for_improvement?: string[] | null;
+          recommendations?: string[] | null;
+          progress_insights?: string | null;
+          user_id?: string | null;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          session_id?: string;
+          summary?: string;
+          strengths?: string[] | null;
+          areas_for_improvement?: string[] | null;
+          recommendations?: string[] | null;
+          progress_insights?: string | null;
+          user_id?: string | null;
+        };
+        Relationships: [];
+      };
       max_onsight_grades: {
         Row: {
           created_at: string;

--- a/src/types/climbing.ts
+++ b/src/types/climbing.ts
@@ -50,14 +50,16 @@ export interface Session {
   isActive: boolean;
   breaks: number;
   totalBreakTime: number;
-  aiAnalysis?: {
-    summary: string;
-    strengths: string[];
-    areasForImprovement: string[];
-    recommendations: string[];
-    progressInsights: string;
-    generatedAt: Date;
-  };
+  aiAnalysis?: AIAnalysis;
+}
+
+export interface AIAnalysis {
+  summary: string;
+  strengths: string[];
+  areasForImprovement: string[];
+  recommendations: string[];
+  progressInsights: string;
+  generatedAt: Date;
 }
 
 // Local climb interface for the frontend


### PR DESCRIPTION
## Summary
- define `AIAnalysis` interface in types
- update `SessionAnalysis` prop to use new type
- load and store session analyses in Supabase
- declare `session_analyses` table in Supabase types

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_68428282865c83318891f4ed5427a959