### PR TITLE
Add AIAnalysisService prompt tests

### DIFF
--- a/src/config/openrouter.ts
+++ b/src/config/openrouter.ts
@@ -1,4 +1,7 @@
-const envApiKey = import.meta.env.VITE_OPENROUTER_API_KEY;
+const envApiKey =
+  (typeof import.meta !== "undefined" &&
+    (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_OPENROUTER_API_KEY) ||
+  process.env.VITE_OPENROUTER_API_KEY;
 
 export const OPENROUTER_CONFIG = {
   baseURL: "https://openrouter.ai/api/v1",

--- a/src/services/__tests__/aiAnalysis.test.ts
+++ b/src/services/__tests__/aiAnalysis.test.ts
@@ -1,0 +1,84 @@
+import { AIAnalysisService } from "../aiAnalysis";
+import type { Session, LocalClimb } from "../../types/climbing";
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+test("generateAnalysisPrompt includes optional fields", () => {
+  const climbs: LocalClimb[] = [
+    {
+      id: "c1",
+      name: "Problem A",
+      grade: "V5",
+      tickType: "send",
+      timestamp: new Date("2024-01-01T10:10:00Z"),
+      attempts: 2,
+      effort: 8,
+      height: 5,
+      timeOnWall: 30,
+      notes: "cruxy",
+    },
+  ];
+
+  const session: Session = {
+    id: "s1",
+    location: "Gym A",
+    climbingType: "boulder",
+    gradeSystem: "V-Scale",
+    notes: "Felt good",
+    startTime: new Date("2024-01-01T10:00:00Z"),
+    endTime: new Date("2024-01-01T12:00:00Z"),
+    climbs,
+    isActive: false,
+    breaks: 2,
+    totalBreakTime: 15,
+  };
+
+  const service = new AIAnalysisService("key");
+  const prompt = (
+    service as unknown as { generateAnalysisPrompt: (s: Session) => string }
+  ).generateAnalysisPrompt(session);
+
+  assert.match(prompt, /Grade system: V-Scale/);
+  assert.match(prompt, /Notes: Felt good/);
+  assert.match(prompt, /Breaks: 2/);
+  assert.match(prompt, /Total break time: 15/);
+  assert.match(prompt, /attempts 2/);
+  assert.match(prompt, /effort 8\/10/);
+  assert.match(prompt, /height 5m/);
+  assert.match(prompt, /time on wall 30s/);
+  assert.match(prompt, /notes: cruxy/);
+});
+
+test("generateAnalysisPrompt omits optional fields when absent", () => {
+  const climbs: LocalClimb[] = [
+    {
+      id: "c2",
+      name: "Route B",
+      grade: "5.11a",
+      tickType: "attempt",
+      timestamp: new Date("2024-01-02T10:00:00Z"),
+    },
+  ];
+
+  const session: Session = {
+    id: "s2",
+    location: "Gym B",
+    climbingType: "sport",
+    startTime: new Date("2024-01-02T10:00:00Z"),
+    climbs,
+    isActive: false,
+    breaks: 0,
+    totalBreakTime: 0,
+  };
+
+  const service = new AIAnalysisService("key");
+  const prompt = (
+    service as unknown as { generateAnalysisPrompt: (s: Session) => string }
+  ).generateAnalysisPrompt(session);
+
+  assert.ok(!prompt.includes("Grade system:"));
+  assert.ok(!prompt.includes("Notes:"));
+  assert.ok(!/attempts\s+\d/.test(prompt));
+  assert.ok(!/height\s+\d/.test(prompt));
+  assert.ok(!/time on wall/.test(prompt));
+});

--- a/src/services/aiAnalysis.ts
+++ b/src/services/aiAnalysis.ts
@@ -89,17 +89,24 @@ export class AIAnalysisService {
         ? efforts.reduce((a, b) => a + b, 0) / efforts.length
         : 0;
 
+    const gradeSystemLine = session.gradeSystem
+      ? `- Grade system: ${session.gradeSystem}`
+      : "";
+    const notesLine = session.notes ? `- Notes: ${session.notes}` : "";
+
     return `Analyze this climbing session and provide specific feedback based on the actual performance data.
 
 SESSION DATA:
 - Location: ${session.location}
 - Type: ${session.climbingType}
-- Duration: ${duration} minutes
+${gradeSystemLine ? `${gradeSystemLine}\n` : ""}${notesLine ? `${notesLine}\n` : ""}- Duration: ${duration} minutes
 - Total climbs: ${session.climbs.length}
 - Sends: ${sends}
 - Failed attempts: ${attempts}
 - Flashes: ${flashes}
 - Onsights: ${onsights}
+- Breaks: ${session.breaks}
+- Total break time: ${session.totalBreakTime} minutes
 - Average effort: ${avgEffort.toFixed(1)}/10
 - Grades: ${grades.join(", ")}
 
@@ -107,7 +114,12 @@ CLIMBS DETAILS:
 ${session.climbs
   .map(
     (climb) =>
-      `- ${climb.name} (${climb.grade}): ${climb.tickType}${climb.effort ? `, effort ${climb.effort}/10` : ""}${climb.notes ? `, notes: ${climb.notes}` : ""}`,
+      `- ${climb.name} (${climb.grade}): ${climb.tickType}` +
+      (climb.attempts !== undefined ? `, attempts ${climb.attempts}` : "") +
+      (climb.effort !== undefined ? `, effort ${climb.effort}/10` : "") +
+      (climb.height !== undefined ? `, height ${climb.height}m` : "") +
+      (climb.timeOnWall !== undefined ? `, time on wall ${climb.timeOnWall}s` : "") +
+      (climb.notes ? `, notes: ${climb.notes}` : ""),
   )
   .join("\n")}
 


### PR DESCRIPTION
## Summary
- test `generateAnalysisPrompt` with and without optional fields
- include grade system, session notes and break info in prompt
- handle optional climb fields in prompt formatting
- allow OpenRouter config to load without Vite env

## Testing
- `npm run lint`
- `npx --yes tsx --test src/services/__tests__/aiAnalysis.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68428041ed8c833186fedbb55c8f3d29